### PR TITLE
(#1) Fix WIin32API error

### DIFF
--- a/lib/puppet/provider/package/cygwin.rb
+++ b/lib/puppet/provider/package/cygwin.rb
@@ -31,18 +31,16 @@ Puppet::Type.type(:package).provide(:cygwin, :parent => Puppet::Provider::Packag
   # found then return nil.
   #
   def self.install_dir
-    require 'win32/registry'
-
     return @install_dir if @install_dir
+
+    require 'win32/registry'
 
     begin
       Win32::Registry::HKEY_LOCAL_MACHINE.open(self::REGISTRY_KEY) do |reg|
         @install_dir = reg['rootdir'].tr '/', '\\'
       end
-
     rescue StandardError => e
       Puppet.debug e
-
     end
   end
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "mdelaney-cygwin",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "summary": "Cygwin Module",
   "author": "Mike Delaney",
   "description": "Puppet module to install and manage packages with cygwin.",
@@ -32,8 +32,10 @@
         "Server 2008 R2",
         "Server 2012",
         "Server 2012 R2",
+        "Server 2016",
         "7",
-        "8"
+        "8",
+        "10"
       ]
     }
   ],
@@ -44,7 +46,7 @@
     },
     {
       "name": "puppet",
-      "version_requirement": ">=3.8.3 <4.0.0"
+      "version_requirement": ">=3.8.3 <7.0.0"
     }
   ]
 }


### PR DESCRIPTION
I'm not sure why this works, but changing the order of the call `require win32/registry` seems to fix the problem described in issue #1.

This also bumps the version to 0.0.7 and adjusts compatibility.