### PR TITLE
Fix handling of source parameter

### DIFF
--- a/lib/puppet/provider/package/cygwin.rb
+++ b/lib/puppet/provider/package/cygwin.rb
@@ -168,18 +168,17 @@ Puppet::Type.type(:package).provide(:cygwin, :parent => Puppet::Provider::Packag
   end
 
   def install
-    source = nil
-
-    fail "You must provide the name of the package to install" if
-      @resource[:name].nil?
+    if @resource[:name].nil?
+      fail "You must provide the name of the package to install"
+    end
 
     flags = ['-q', '-P', name]
     unless @resource[:install_options].nil?
       flags << @resource[:install_options]
     end
 
-    unless source = @resource[:source]
-      flags = flags.concat ['-s', source]
+    unless @resource[:source].nil?
+      flags = flags.concat ['-s', @resource[:source]]
     end
 
     self.class.cygwin(flags)


### PR DESCRIPTION
The logic for deciding when to pass along the source parameter was reversed. I'm not really sure how this used to work.