### PR TITLE
cygwin::windows_path() function

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ##Overview
 
-This module installs Cygwin and adds Cygwin as a package provider in Puppet.   
+This module installs Cygwin and adds Cygwin as a package provider in Puppet.
 
 ##Module Description
 
@@ -38,6 +38,15 @@ include '::cygwin'
 ####Private Classes
 
 ###Parameters
+
+###Functions
+
+#### `cygwin::windows_path($cygwin_path)`
+
+Take a UNIX-style path used in Cygwin and convert it to a Windows path. For example:
+
+* `cygwin::windows_path('/etc/motd') == 'C:\Cygwin64\etc\motd`
+* `cygwin::windows_path('/cygrive/c/ProgramData') == 'C:\ProgramData`
 
 ##Limitations
 

--- a/functions/windows_path.pp
+++ b/functions/windows_path.pp
@@ -1,0 +1,20 @@
+# Get a Windows path from a Cygwin path.
+function cygwin::windows_path ( Stdlib::Unixpath $path ) >> Stdlib::Windowspath {
+  # Convert /cygrive/ paths, e.g. /cydrive/c/, to Windows paths, e.g. c:/
+  $path2 = $path.regsubst('^/cygdrive/(\w+)', '\1:', 'I')
+
+  # Convert all / to \
+  $path3 = $path2.regsubst('/+', '\\', 'G')
+
+  if $facts['cygwin_home'] !~ String[1] {
+    # If this happens, this function could generate bad paths.
+    fail('Function cygwin::windows_path requires cygwin_home fact. It should be set by this module.')
+  }
+
+  if $path2 == $path {
+    # It wasn't a /cygdrive/ path
+    "${facts['cygwin_home']}${path3}"
+  } else {
+    $path3
+  }
+}

--- a/metadata.json
+++ b/metadata.json
@@ -41,12 +41,8 @@
   ],
   "requirements": [
     {
-      "name": "pe",
-      "version_requirement": ">=3.8.3 <4.0.0"
-    },
-    {
       "name": "puppet",
-      "version_requirement": ">=3.8.3 <7.0.0"
+      "version_requirement": ">=4.1.0 <7.0.0"
     }
   ]
 }


### PR DESCRIPTION
Converts Cygwin paths, e.g. `/etc/motd` and `/cygrive/c/ProgramData`, into their Windows-native equivalents, e.g. `C:\Cygwin64\etc\motd` and `C:\ProgramData`.

Puppet language functions were introduced in Puppet 4.1.0, so this updates the language version compatibility. I'm reasonably confident you could use this module on older versions of Puppet, though — you just won't be able to use the function.