### PR TITLE
 Update README.md for GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ##Overview
 
-This module installs Cygwin and adds Cygwin as a package provider in Puppet.   
+This module installs Cygwin and adds Cygwin as a package provider in Puppet.
 
 ##Module Description
 
@@ -38,6 +38,15 @@ include '::cygwin'
 ####Private Classes
 
 ###Parameters
+
+###Functions
+
+#### `cygwin::windows_path($cygwin_path)`
+
+Take a UNIX-style path used in Cygwin and convert it to a Windows path. For example:
+
+* `cygwin::windows_path('/etc/motd') == 'C:\Cygwin64\etc\motd`
+* `cygwin::windows_path('/cygrive/c/ProgramData') == 'C:\ProgramData`
 
 ##Limitations
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-#Cygwin
+# Cygwin
 
-####Table of Contents
+#### Table of Contents
 
 1. [Overview](#overview)
 2. [Module Description - What the module does and why it is useful](#module-description)
@@ -9,37 +9,37 @@
 5. [Limitations - OS compatibility, etc.](#limitations)
 6. [Development - Guide for contributing to the module](#development)
 
-##Overview
+## Overview
 
 This module installs Cygwin and adds Cygwin as a package provider in Puppet.
 
-##Module Description
+## Module Description
 
 This module will download the Cygwin setup executable and install it. This will install the standard set of cygwin tools to the standard cygwin location.
 
-##Usage
+## Usage
 
 If you want to use cygwin as a package provider, it must be installed first.
 
-###Install Cygwin
+### Install Cygwin
 
 ```puppet
 include '::cygwin'
 ```
 
-##Reference
+## Reference
 
-###Classes
+### Classes
 
-####Public Classes
+#### Public Classes
 
 * cygwin: Main Class, includes all other classes.
 
-####Private Classes
+#### Private Classes
 
-###Parameters
+### Parameters
 
-###Functions
+### Functions
 
 #### `cygwin::windows_path($cygwin_path)`
 
@@ -48,10 +48,10 @@ Take a UNIX-style path used in Cygwin and convert it to a Windows path. For exam
 * `cygwin::windows_path('/etc/motd') == 'C:\Cygwin64\etc\motd`
 * `cygwin::windows_path('/cygrive/c/ProgramData') == 'C:\ProgramData`
 
-##Limitations
+## Limitations
 
 For obvious reasons, this module will only work on the Windows operating system.
 
-##Development
+## Development
 
-Please see the Puppet guidelines for module contribution. http://projects.puppetlabs.com/projects/module-site/wiki/Module_contributing
+Please see the [Puppet guidelines for module contribution](https://puppet.com/docs/puppet/6.1/contributing.html).

--- a/functions/windows_path.pp
+++ b/functions/windows_path.pp
@@ -1,0 +1,20 @@
+# Get a Windows path from a Cygwin path.
+function cygwin::windows_path ( Stdlib::Unixpath $path ) >> Stdlib::Windowspath {
+  # Convert /cygrive/ paths, e.g. /cydrive/c/, to Windows paths, e.g. c:/
+  $path2 = $path.regsubst('^/cygdrive/(\w+)', '\1:', 'I')
+
+  # Convert all / to \
+  $path3 = $path2.regsubst('/+', '\\', 'G')
+
+  if $facts['cygwin_home'] !~ String[1] {
+    # If this happens, this function could generate bad paths.
+    fail('Function cygwin::windows_path requires cygwin_home fact. It should be set by this module.')
+  }
+
+  if $path2 == $path {
+    # It wasn't a /cygdrive/ path
+    "${facts['cygwin_home']}${path3}"
+  } else {
+    $path3
+  }
+}

--- a/metadata.json
+++ b/metadata.json
@@ -41,12 +41,8 @@
   ],
   "requirements": [
     {
-      "name": "pe",
-      "version_requirement": ">=3.8.3 <4.0.0"
-    },
-    {
       "name": "puppet",
-      "version_requirement": ">=3.8.3 <7.0.0"
+      "version_requirement": ">=4.1.0 <7.0.0"
     }
   ]
 }


### PR DESCRIPTION
GitHub wants spaces between # and the header text.

This also updates the link to the Puppet module contribution guidelines.

This is built on https://github.com/madelaney/puppet-cygwin/pull/6 to avoid merge conflicts.