### PR TITLE
Add cygwin::enable parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,13 +4,20 @@
 #
 # == Parameters
 #
+# [*enable*]
+#   Whether or not to install Cygwin. This is used by a number of other modules
+#   to check if Cygwin is installed.
+#
+#   If for some reason you need to use cygwin::windows_path() on non-Cygwin
+#   nodes, you should set this to false. This defaults to true.
+#
 # [*install_root*]
 #   The root of the Cygwin install, this defaults to 'C:\Cygwin' on
 #   x86 systems, and 'C:\Cygwin64' on x86_64 systems.
 #
 # [*host*]
 #   The Cygwin host to download Cygwin setup binary from
-
+#
 # [*mirror*]
 #   The host to set the Cygwin mirror to. This will default to where all
 #   future packages are installed from.
@@ -22,6 +29,7 @@
 #   Defines an array of packages to install after Cygwin is installed
 #
 class cygwin (
+  $enable       = true,
   $install_root = $cygwin::params::install_root,
   $host         = $cygwin::params::host,
   $mirror       = $cygwin::params::mirror,
@@ -30,7 +38,9 @@ class cygwin (
   $packages     = {},
 ) inherits cygwin::params {
 
-  include cygwin::install
+  if $enable {
+    include cygwin::install
 
-  create_resources('cygwin::package', $packages)
+    create_resources('cygwin::package', $packages)
+  }
 }


### PR DESCRIPTION
It's occasionally useful to use `cygwin::windows_path()` on non-Cygwin nodes, e.g. for exported resources. That can now be done by setting `enable` to `false`.

Additionally, a few of the modules I've been working on need to know if Cygwin will be used before it is installed (on the first run). For example, [ploperations/ssh][] needs to know if it should installed Cygwin OpenSSH or native OpenSSH.

[ploperations/ssh]: https://github.com/ploperations/ploperations-ssh