### PR TITLE
Allow cygwin::windows_path to be used on first run

### DIFF
--- a/functions/windows_path.pp
+++ b/functions/windows_path.pp
@@ -1,20 +1,15 @@
 # Get a Windows path from a Cygwin path.
 function cygwin::windows_path ( Stdlib::Unixpath $path ) >> Stdlib::Windowspath {
+  # Needed to determine the Cygwin root directory
+  include cygwin
+
   # Convert /cygrive/ paths, e.g. /cydrive/c/, to Windows paths, e.g. c:/
   $path2 = $path.regsubst('^/cygdrive/(\w+)', '\1:', 'I')
 
-  # Convert all / to \
-  $path3 = $path2.regsubst('/+', '\\', 'G')
-
-  if $facts['cygwin_home'] !~ String[1] {
-    # If this happens, this function could generate bad paths.
-    fail('Function cygwin::windows_path requires cygwin_home fact. It should be set by this module.')
-  }
-
   if $path2 == $path {
     # It wasn't a /cygdrive/ path
-    "${facts['cygwin_home']}${path3}"
+    "${cygwin::install_root}${path2}".regsubst('/+', '\\', 'G')
   } else {
-    $path3
+    $path2.regsubst('/+', '\\', 'G')
   }
 }


### PR DESCRIPTION
This switches from using `$facts['cygwin_home']` to using `cygwin::install_dir`. The fact isn't available before Cygwin is installed, which previously caused `cygwin::windows_path` to fail, which in turn prevented Cygwin from being installed.