### PR TITLE
Handle the run before Cygwin is installed better

### DIFF
--- a/lib/puppet/feature/cygwin.rb
+++ b/lib/puppet/feature/cygwin.rb
@@ -1,0 +1,27 @@
+require 'puppet/util/feature'
+
+# Ensure that Cygwin is installed and ready to go.
+Puppet.features.add(:cygwin) do
+  return false if ! Puppet::Util::Platform.windows?
+
+  begin
+    require 'Win32API'
+    require 'win32/registry'
+  rescue LoadError => e
+    Puppet.warning("Cygwin packages need the win32-registry gem: #{e}")
+    return false
+  end
+
+  install_dir = nil
+  begin
+    Win32::Registry::HKEY_LOCAL_MACHINE.open('SOFTWARE\Cygwin\setup') do |reg|
+      install_dir = reg['rootdir'].tr '/', '\\'
+    end
+  rescue StandardError => e
+    Puppet.debug("Cygwin packages need SOFTWARE\\Cygwin\\setup in the registry: #{e}")
+    return false
+  end
+
+  Puppet::FileSystem.executable?(File.join install_dir, 'bin', 'cygcheck.exe') \
+    && Puppet::FileSystem.executable?(File.join install_dir, 'bin', 'setup.exe')
+end

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -54,7 +54,11 @@ class cygwin::install(
       command => "${installer} ${_final_command_args}",
       cwd     => "${::staging_windir}\\cygwin",
       path    => ["${::staging_windir}\\cygwin"],
-      creates => "${install_root}\\Cygwin.bat";
+      creates => "${install_root}\\Cygwin.bat",
+      require => [
+        File[$install_root],
+        File["${::staging_windir}\\cygwin\\${installer}"],
+      ];
   }
 
   # NOTE (madelaney)
@@ -66,6 +70,7 @@ class cygwin::install(
       ensure             => file,
       source             => "${::staging_windir}\\cygwin\\${installer}",
       source_permissions => ignore,
-      mode               => '0755';
+      mode               => '0755',
+      require            => Exec['Install Cygwin'];
   }
 }


### PR DESCRIPTION
* Ensure that the install steps are performed in the correct order.
* Ensure that we don't try to install Cygwin packages until after Cygwin is installed. This is done with a feature — Puppet will put off installing the packages as long as possible if the feature isn't available.
* `install_directory` isn't set before Cygwin is installed. Support that case, and the case where Puppet is running on a node where Cygwin isn't used at all.
* Ensure Win32API is loaded before win32-registry gem. This seems to be what other Windows providers do.